### PR TITLE
feat: update ubuntu image, speed up buildtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@
 #     docker run -it --rm libmpc bash
 # ------------------------------------------------------------------------------
 
-FROM ubuntu:bionic
+FROM ubuntu:latest
 
 LABEL maintainer="kealanmccusker@gmail.com"
 
@@ -46,15 +46,15 @@ RUN git clone https://github.com/apache/incubator-milagro-crypto-c.git && \
     cd build && \
     cmake -D CMAKE_BUILD_TYPE=Release -D BUILD_SHARED_LIBS=ON -D AMCL_CHUNK=64 -D AMCL_CURVE="BLS381,SECP256K1" -D AMCL_RSA="" -D BUILD_PAILLIER=ON -D BUILD_PYTHON=OFF -D BUILD_BLS=ON -D BUILD_WCC=OFF -D BUILD_MPIN=OFF -D BUILD_X509=OFF -D CMAKE_INSTALL_PREFIX=/usr/local .. && \
     make && \
-    make test  ARGS=-j8 && \
-    make install
+    make test ARGS=-j8 && \
+    make install/fast
 
 ADD . /root
 
 RUN ./scripts/build.sh
 
 RUN cd ./target/Release && \
-    make install
+    make -j8 install
 
 CMD ./scripts/test.sh
 


### PR DESCRIPTION
* update reference ubuntu implementation to latest LTS (fixes build on arm)
* speed up the build process by adding /fast target and -j8 to the MPC build