### PR TITLE
Fix challenge generation in Schnorr proof

### DIFF
--- a/include/amcl/cg21/cg21_utilities.h
+++ b/include/amcl/cg21/cg21_utilities.h
@@ -31,7 +31,7 @@ under the License.
 #define CG21_PI_PRM_INVALID_FORMAT          3130308     /**< An octet value has an invalid format */
 
 #define CG21_PAILLIER_PROOF_SIZE  CG21_PAILLIER_PROOF_ITERS * FS_2048 /**< Length of components of the Proof in bytes */
-#define CG21_PAILLIER_PROOF_ITERS           80                        /**< Iterations necessary for the Proof of Paillier N */
+#define CG21_PAILLIER_PROOF_ITERS           128                        /**< Iterations necessary for the Proof of Paillier N */
 
 #include "amcl/amcl.h"
 #include "amcl/modulus.h"

--- a/src/cg21/cg21_pi_factor.c
+++ b/src/cg21/cg21_pi_factor.c
@@ -164,7 +164,7 @@ void CG21_PI_FACTOR_COMMIT(csprng *RNG, CG21_PiFACTOR_SECRETS *r1priv, CG21_PiFA
     BIG_1024_58 t[FFLEN_2048];
     BIG_1024_58 Q[FFLEN_2048];
     BIG_1024_58 t1[FFLEN_2048];
-    BIG_1024_58 t2[2*FFLEN_2048];
+    BIG_1024_58 t2[FFLEN_2048+HFLEN_2048];
     BIG_1024_58 t3[FFLEN_2048 + HFLEN_2048];
     BIG_1024_58 t4[3*FFLEN_2048];
     BIG_1024_58 t5[2*FFLEN_2048 + HFLEN_2048];
@@ -224,6 +224,7 @@ void CG21_PI_FACTOR_COMMIT(csprng *RNG, CG21_PiFACTOR_SECRETS *r1priv, CG21_PiFA
 
     // Generate mu in [0, .., Pedersen_N * q]
     CG21_FF_2048_amul(t2, q, HFLEN_2048, pub_com->N, FFLEN_2048);
+    FF_2048_norm(t2, FFLEN_2048 + HFLEN_2048);
     FF_2048_random(mu, RNG, FFLEN_2048 + HFLEN_2048);
     FF_2048_mod(mu, t2, FFLEN_2048 + HFLEN_2048);
     FF_2048_toOctet(r1priv->mu,mu,FFLEN_2048 + HFLEN_2048);
@@ -235,18 +236,21 @@ void CG21_PI_FACTOR_COMMIT(csprng *RNG, CG21_PiFACTOR_SECRETS *r1priv, CG21_PiFA
 
     // Generate sigma in [0, .., Paillier_N * Pedersen_N * q]
     CG21_FF_2048_amul(t4, q, HFLEN_2048, n2, 2*FFLEN_2048);
+    FF_2048_norm(t4, 2*FFLEN_2048 + HFLEN_2048);
     FF_2048_random(sigma, RNG, 2*FFLEN_2048 + HFLEN_2048);
     FF_2048_mod(sigma, t4, 2*FFLEN_2048 + HFLEN_2048);
     FF_2048_toOctet(r1pub->sigma,sigma,2*FFLEN_2048 + HFLEN_2048);
 
     // Generate r in [0, .., Paillier_N * Pedersen_N * q^3]
     CG21_FF_2048_amul(t4, q3, HFLEN_2048, n2, 2*FFLEN_2048);
+    FF_2048_norm(t4, 2*FFLEN_2048 + HFLEN_2048);
     FF_2048_random(r, RNG, 2*FFLEN_2048 + HFLEN_2048);
     FF_2048_mod(r, t4, 2*FFLEN_2048 + HFLEN_2048);
     FF_2048_toOctet(r1priv->r,r,2*FFLEN_2048 + HFLEN_2048);
 
     // Generate x in [0, .., Pedersen_N * q^3]
     CG21_FF_2048_amul(t2, q3, HFLEN_2048, pub_com->N, FFLEN_2048);
+    FF_2048_norm(t2, FFLEN_2048 + HFLEN_2048);
     FF_2048_random(x, RNG, FFLEN_2048 + HFLEN_2048);
     FF_2048_mod(x, t2, FFLEN_2048 + HFLEN_2048);
     FF_2048_toOctet(r1priv->x,x,FFLEN_2048 + HFLEN_2048);
@@ -393,8 +397,8 @@ void CG21_PI_FACTOR_PROVE(const CG21_PiFACTOR_SECRETS *r1priv, const CG21_PiFACT
     OCT_pad(&OCT, FS_2048+HFS_2048);
     FF_2048_fromOctet(t5, &OCT, FFLEN_2048+HFLEN_2048);
 
-    CG21_FF_2048_amul(t7, e_, HFLEN_2048, qF, FFLEN_2048); // t7 = e*p
-    FF_2048_add(t8, t7, t5, FFLEN_2048+HFLEN_2048);                // t3 = e*p + alpha
+    CG21_FF_2048_amul(t7, e_, HFLEN_2048, qF, FFLEN_2048); // t7 = e*q
+    FF_2048_add(t8, t7, t5, FFLEN_2048+HFLEN_2048);                // t3 = e*q + beta
     FF_2048_norm(t8, FFLEN_2048+HFLEN_2048);
     FF_2048_toOctet(proof->z2,t8,FFLEN_2048+HFLEN_2048);
 

--- a/src/cg21/cg21_reshare.c
+++ b/src/cg21/cg21_reshare.c
@@ -626,7 +626,8 @@ void CG21_KEY_RESHARE_SUM_SHARES(const SSS_shares *share, CG21_RESHARE_ROUND4_ST
     }
 }
 
-static int CG21_KEY_RESHARE_GEN_CHALLENGE(int myID, int n, const octet *X, CG21_SSID *ssid, const octet *rho, octet *out){
+static int CG21_KEY_RESHARE_GEN_CHALLENGE(int myID, int n, const octet *X, CG21_SSID *ssid,
+                                          const octet *rho, octet *out, octet *A){
     hash256 sha;
     BIG_256_56 q;
     BIG_256_56 e;
@@ -636,7 +637,7 @@ static int CG21_KEY_RESHARE_GEN_CHALLENGE(int myID, int n, const octet *X, CG21_
     HASH256_init(&sha);
 
     HASH_UTILS_hash_oct(&sha, X);
-
+    HASH_UTILS_hash_oct(&sha, A);
     //Process i||len(i) into sha
     HASH_UTILS_hash_i2osp4(&sha, myID);
     HASH_UTILS_hash_i2osp4(&sha, CG21_calculateBitLength (myID));
@@ -687,7 +688,7 @@ static int key_reshare_prove_helper(const CG21_RESHARE_ROUND4_STORE *r3Store, CG
     BIG_256_56_zero(accum);
 
     // compute challenge
-    int rc = CG21_KEY_RESHARE_GEN_CHALLENGE(myID, n, &X, ssid, rho, &E);
+    int rc = CG21_KEY_RESHARE_GEN_CHALLENGE(myID, n, &X, ssid, rho, &E, A);
     if (rc!=CG21_OK){
         return rc;
     }
@@ -776,7 +777,7 @@ static int key_reshare_verify_helper(const CG21_RESHARE_ROUND4_OUTPUT *input, CG
 
     char e2[SGS_SECP256K1];
     octet E = {0, sizeof(e2), e2};
-    rc = CG21_KEY_RESHARE_GEN_CHALLENGE(hisID, setting.n1, &Xi_, ssid, r3Store->rho, &E);
+    rc = CG21_KEY_RESHARE_GEN_CHALLENGE(hisID, setting.n1, &Xi_, ssid, r3Store->rho, &E, input->proof.A);
 
     if (rc!=CG21_OK){
         return rc;

--- a/src/cg21/cg21_rp_pi_affg.c
+++ b/src/cg21/cg21_rp_pi_affg.c
@@ -111,24 +111,28 @@ int Piaffg_Sample_and_Commit(csprng *RNG, PAILLIER_private_key *paillier_priv, P
     // Generate gamma in [0, .., Nt * q^3]
     // See Remark 1 at the top for more information
     CG21_FF_2048_amul(gamma_mod, q3, HFLEN_2048, pedersen_pub->N, FFLEN_2048);   //Nt*q^3
+    FF_2048_norm(gamma_mod, FFLEN_2048 + HFLEN_2048);
     FF_2048_random(secrets->gamma, RNG, FFLEN_2048 + HFLEN_2048);           //gamma: a (1024+2048)-bit number
     FF_2048_mod(secrets->gamma, gamma_mod, FFLEN_2048 + HFLEN_2048);            //gamma: (3*256+2048-bit) number
 
     // Generate delta in [0, .., Nt * q^3]
     // See Remark 1 at the top for more information
     CG21_FF_2048_amul(delta_mod, q3, HFLEN_2048, pedersen_pub->N, FFLEN_2048);   //Nt*q^3
+    FF_2048_norm(delta_mod, FFLEN_2048 + HFLEN_2048);
     FF_2048_random(secrets->delta, RNG, FFLEN_2048 + HFLEN_2048);           //delta: a (1024+2048)-bit number
     FF_2048_mod(secrets->delta, delta_mod, FFLEN_2048 + HFLEN_2048);            //delta: (3*256+2048-bit) number
 
     // Generate m in [0, .., Nt * q]
     // See Remark 1 at the top for more information
     CG21_FF_2048_amul(m_mod, q, HFLEN_2048, pedersen_pub->N, FFLEN_2048);
+    FF_2048_norm(m_mod, FFLEN_2048 + HFLEN_2048);
     FF_2048_random(secrets->m, RNG, FFLEN_2048 + HFLEN_2048);         //m: a (1024+2048)-bit number
     FF_2048_mod(secrets->m, m_mod, FFLEN_2048 + HFLEN_2048);             //m: (256+2048-bit) number
 
     // Generate mu in [0, .., Nt * q]
     // See Remark 1 at the top for more information
     CG21_FF_2048_amul(mu_mod, q, HFLEN_2048, pedersen_pub->N, FFLEN_2048);
+    FF_2048_norm(mu_mod, FFLEN_2048 + HFLEN_2048);
     FF_2048_random(secrets->mu, RNG, FFLEN_2048 + HFLEN_2048);         //mu: a (1024+2048)-bit number
     FF_2048_mod(secrets->mu, mu_mod, FFLEN_2048 + HFLEN_2048);             //mu: (256+2048)-bit number
 
@@ -207,7 +211,7 @@ int Piaffg_Sample_and_Commit(csprng *RNG, PAILLIER_private_key *paillier_priv, P
     FF_4096_norm(PUB.n2, FFLEN_4096);
 
     // Computes By
-    FF_2048_toOctet(&ry_oct, secrets->ry, 2*FFLEN_2048);
+    FF_2048_toOctet(&ry_oct, secrets->ry, FFLEN_2048);
     OCT_pad(&ry_oct, FS_4096);
 
     PAILLIER_ENCRYPT(NULL, &PUB, &beta_oct, &CT_oct,&ry_oct);
@@ -415,7 +419,7 @@ void Piaffg_Prove(PAILLIER_public_key *prover_paillier_pub, PAILLIER_public_key 
     FF_2048_fromOctet(n, &OCT, FFLEN_2048);
 
     FF_2048_copy(ws, dws, FFLEN_2048);
-    FF_2048_dmod(ws, ws, n, FFLEN_2048);
+    FF_2048_mod(ws, n, FFLEN_2048);
 
     FF_2048_ct_pow(ws, ws, e, n, FFLEN_2048, HFLEN_2048);   // ws <- rho_y^e
 

--- a/src/cg21/cg21_rp_pi_affp.c
+++ b/src/cg21/cg21_rp_pi_affp.c
@@ -209,10 +209,10 @@ int PiAffp_Sample_and_Commit(csprng *RNG, PAILLIER_private_key *paillier_priv, P
     FF_4096_norm(PUB.n2, FFLEN_4096);
 
     // Computes Bx and By
-    FF_2048_toOctet(&rx_oct, secrets->rx, 2*FFLEN_2048);
-    OCT_pad(&rx_oct, FS_4096);
+    FF_2048_toOctet(&rx_oct, secrets->rx, FFLEN_2048);
+    FF_2048_toOctet(&ry_oct, secrets->ry, FFLEN_2048);
 
-    FF_2048_toOctet(&ry_oct, secrets->ry, 2*FFLEN_2048);
+    OCT_pad(&rx_oct, FS_4096);
     OCT_pad(&ry_oct, FS_4096);
 
     PAILLIER_ENCRYPT(NULL, &PUB, &alpha_oct, &CT_oct,&rx_oct); // Bx = Enc(alpha; rx)
@@ -411,7 +411,7 @@ void PiAffp_Prove(PAILLIER_public_key *prover_paillier_pub, PAILLIER_public_key 
     FF_4096_toOctet(&OCT, prover_paillier_pub->n, HFLEN_4096);
     FF_2048_fromOctet(n, &OCT, FFLEN_2048);
 
-    FF_2048_dmod(ws, ws, n, FFLEN_2048);
+    FF_2048_mod(ws, n, FFLEN_2048);
     FF_2048_ct_pow(ws, ws, e, n, FFLEN_2048, HFLEN_2048);   // ws <- rho_x^e
 
     FF_2048_zero(dws, 2*FFLEN_2048);
@@ -425,7 +425,7 @@ void PiAffp_Prove(PAILLIER_public_key *prover_paillier_pub, PAILLIER_public_key 
     FF_4096_toOctet(&OCT, prover_paillier_pub->n, HFLEN_4096);
     FF_2048_fromOctet(n, &OCT, FFLEN_2048);
 
-    FF_2048_dmod(ws, ws, n, FFLEN_2048);
+    FF_2048_mod(ws, n, FFLEN_2048);
     FF_2048_ct_pow(ws, ws, e, n, FFLEN_2048, HFLEN_2048);
 
     FF_2048_mul(dws, secrets->ry, ws, FFLEN_2048);

--- a/src/cg21/cg21_rp_pi_enc.c
+++ b/src/cg21/cg21_rp_pi_enc.c
@@ -94,11 +94,13 @@ int PiEnc_Sample_randoms_and_commit(csprng *RNG, PAILLIER_private_key *priv_key,
 
     // Generate gamma in [0, .., Nt * q^3]
     CG21_FF_2048_amul(gamma_mod, q3, HFLEN_2048, pub_com->N, FFLEN_2048);   //Nt*q^3
+    FF_2048_norm(gamma_mod, FFLEN_2048 + HFLEN_2048);
     FF_2048_random(secrets->gamma, RNG, FFLEN_2048 + HFLEN_2048);           //gamma_mod: a (1024+2048)-bit number
     FF_2048_mod(secrets->gamma, gamma_mod, FFLEN_2048 + HFLEN_2048);            //gamma_mod: in [0, .., 3*256+2048]
 
     // Generate mu in [0, .., Nt * q]
     CG21_FF_2048_amul(mu_mod, q, HFLEN_2048, pub_com->N, FFLEN_2048);
+    FF_2048_norm(mu_mod, FFLEN_2048 + HFLEN_2048);
     FF_2048_random(secrets->mu, RNG, FFLEN_2048 + HFLEN_2048);         //mu_mod: a (1024+2048)-bit number
     FF_2048_mod(secrets->mu, mu_mod, FFLEN_2048 + HFLEN_2048);             //mu_mod: in [0, .., 256+2048]
 

--- a/src/cg21/cg21_rp_pi_logstar.c
+++ b/src/cg21/cg21_rp_pi_logstar.c
@@ -99,11 +99,13 @@ int PiLogstar_Sample_and_commit(csprng *RNG, PAILLIER_private_key *priv_key, PED
 
     // Generate mu_mod in [0, .., Nt * q^3]
     CG21_FF_2048_amul(gamma_mod, q3, HFLEN_2048, pub_com->N, FFLEN_2048);   //Nt*q^3
+    FF_2048_norm(gamma_mod,FFLEN_2048 + HFLEN_2048);
     FF_2048_random(secrets->gamma, RNG, FFLEN_2048 + HFLEN_2048);           //gamma_mod: a (1024+2048)-bit number
     FF_2048_mod(secrets->gamma, gamma_mod, FFLEN_2048 + HFLEN_2048);            //gamma_mod: in [0, .., 3*256+2048]
 
     // Generate mu_mod in [0, .., Nt * q]
     CG21_FF_2048_amul(mu_mod, q, HFLEN_2048, pub_com->N, FFLEN_2048);
+    FF_2048_norm(mu_mod,FFLEN_2048 + HFLEN_2048);
     FF_2048_random(secrets->mu, RNG, FFLEN_2048 + HFLEN_2048);         //mu_mod: a (1024+2048)-bit number
     FF_2048_mod(secrets->mu, mu_mod, FFLEN_2048 + HFLEN_2048);             //mu_mod: in [0, .., 256+2048]
 

--- a/src/cg21/cg21_utilities.c
+++ b/src/cg21/cg21_utilities.c
@@ -467,7 +467,7 @@ void CG21_GET_CURVE_ORDER(BIG_1024_58 *q){
     BIG_256_56_toBytes(q_oct.val, q_);
     q_oct.len = EGS_SECP256K1;
 
-    char q_hex[64];
+    char q_hex[2*MODBYTES_256_56+1];
     OCT_toHex(&q_oct, q_hex);
 
     char oct2[2 * FS_2048];


### PR DESCRIPTION
## Fixes challenge generation 
The functions in KeyGen and Key Re-Sharing protocols to also take Schnorr commitment as a parameter for computation of the challenge.

---------------------
### ACCEPTANCE CRITERIA
1. The Schnorr commitment is taken as a parameter for challenge generation
2. Examples should run with no error


closes #57